### PR TITLE
Modernize Docker Compose usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-RUN_CONTEXT ?= docker-compose run --rm
+RUN_CONTEXT ?= docker compose run --rm
 
 init:
 	$(RUN_CONTEXT) terraform init

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   terraform:
     image: hashicorp/terraform:1.3.7


### PR DESCRIPTION
## Why

Docker Compose v2 usage is now standard, so this update aligns the project with current Compose conventions.

## What

Updated the Makefile to use the Docker Compose v2 command and renamed the Compose file to the modern compose.yaml name.