### PR TITLE
Pin AWS provider to 6.50.0

### DIFF
--- a/src/provider.tf
+++ b/src/provider.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "= 6.50.0"
     }
   }
 


### PR DESCRIPTION
## Why

AWS provider version should be fixed to the requested release to make Terraform runs use the exact provider version.

## What

Pinned the hashicorp/aws provider constraint to 6.50.0.